### PR TITLE
chore: update license from MIT to Apache-2.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "chatgpt-app-typescript-template",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "workspaces": [
         "server",
         "widgets"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",


### PR DESCRIPTION
Relects actual license file in the project which is Apache-2.0

relates to #4
