### PR TITLE
feat: move from mcp inspector to MCPJam

### DIFF
--- a/mcp-inspector.json
+++ b/mcp-inspector.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chatgpt-app-template": {
+      "type": "streamable-http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:widgets": "npm run dev --workspace=widgets",
     "serve:widgets": "npm run serve --workspace=widgets",
     "storybook": "npm run storybook --workspace=widgets",
-    "inspect": "npx @modelcontextprotocol/inspector http://localhost:8080/mcp",
+    "inspect": "npx @mcpjam/inspector@latest --config mcp-inspector.json",
     "build": "npm run build:widgets && npm run build:server",
     "build:server": "npm run build --workspace=server",
     "build:widgets": "npm run build --workspace=widgets",


### PR DESCRIPTION
Moves from the [standard MCP inpspector](https://modelcontextprotocol.io/docs/tools/inspector) to a more feature rich MCP inspector, [MCPJam](https://www.mcpjam.com/).

![CleanShot 2026-01-03 at 09 22 36](https://github.com/user-attachments/assets/8727ae35-0f3e-436a-849c-f3b5787c1a3c)

Closes #10