### PR TITLE
update hono and lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5574,9 +5574,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
+      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6746,7 +6746,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7589,7 +7591,7 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
+      "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",


### PR DESCRIPTION
Update hono from 4.11.1 to 4.11.5. Update lodash from 4.17.21 to 4.17.23.

Manually sync the version of qs to 6.14.1 in the package-lock.json file — the "resolved" URL is for 6.14.1 but somehow the "version" is still at 6.14.0. (I think this was preventing `npm audit fix` from working correctly.)

Related:
- https://github.com/pomerium/chatgpt-app-typescript-template/security/dependabot/2
- https://github.com/pomerium/chatgpt-app-typescript-template/security/dependabot/5
- https://github.com/pomerium/chatgpt-app-typescript-template/security/dependabot/6