### PR TITLE
chore: add dependabot configuration for npm and storybook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      npm_and_yarn:
+        exclude-patterns:
+          - "storybook"
+          - "@storybook/*"


### PR DESCRIPTION
Groups storybook updates so they always get the same version when dependabot runs.

Closes #29