### PR TITLE
feat: add add-widget and create-mcp-tool agent skills

### DIFF
--- a/.agents/skills/add-widget/SKILL.md
+++ b/.agents/skills/add-widget/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: add-widget
+description: Add a new widget (React UI + MCP tool) to this template. Use when asked to "add a widget", "add a new tool with UI", "create a new widget", "scaffold a widget", or "build a new MCP App feature".
+metadata:
+  author: nickytonline
+  version: "1.0.0"
+---
+
+# Add a Widget to This Template
+
+This template has its own widget build system that differs from the generic ext-apps examples. Before reading the steps below, fetch the upstream `create-mcp-app` skill for core SDK patterns, then apply those patterns using the template-specific conventions described here:
+
+```
+https://raw.githubusercontent.com/modelcontextprotocol/ext-apps/main/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
+```
+
+Use WebFetch to retrieve that skill now. The steps below describe what is **different** in this template — follow both together.
+
+---
+
+## How This Template Differs from the Generic SDK Examples
+
+| Generic ext-apps approach | This template |
+|---|---|
+| `vite-plugin-singlefile` → single HTML file | Custom `vite-plugin-widgets` → auto-discovery, content hashing, parallel builds |
+| One `vite.config.ts` per project | `widgets/vite.config.ts` handles all widgets automatically |
+| `tsx server.ts` to run | `npm run dev` starts server + widget dev server together |
+| Manual resource registration with `fs.readFile` | `readWidgetHtml()` in `server/src/server.ts` handles dev/prod/CDN automatically |
+| No Storybook | Storybook configured — add a `.stories.tsx` for your component |
+
+**Never** edit files in `assets/` directly — they are generated artifacts.
+
+---
+
+## Step 1: Add the Zod Schema and Types
+
+Edit `server/src/types.ts`. Follow the existing `EchoToolInput` / `EchoToolOutput` pattern:
+
+```typescript
+// Input schema
+export const MyToolInputSchema = z.object({
+  param: z.string().describe('Description of the param'),
+});
+export type MyToolInput = z.infer<typeof MyToolInputSchema>;
+
+// Structured output (passed to the widget via structuredContent)
+export interface MyToolOutput {
+  result: string;
+  timestamp: string;
+  [key: string]: unknown;
+}
+```
+
+---
+
+## Step 2: Register the Tool and Resource
+
+Edit `server/src/server.ts`. Follow the existing `ECHO_WIDGET` / `registerAppTool` / `registerAppResource` pattern:
+
+1. Add a `WidgetDescriptor` constant near the top (alongside `ECHO_WIDGET`):
+
+```typescript
+const MY_WIDGET: WidgetDescriptor = {
+  id: 'my-widget',      // must match the widget filename without .tsx
+  title: 'My Widget',
+  uri: 'ui://my-widget',
+};
+```
+
+2. Add the widget ID to the `widgetIds` array in `main()`:
+
+```typescript
+const widgetIds = [ECHO_WIDGET.id, MY_WIDGET.id];
+```
+
+3. Inside `createMcpServer()`, register the resource and tool following the echo pattern exactly — use `readWidgetHtml(widgetId)` and the existing CSP construction block. The `canRenderUiByCapability` check must wrap `_meta.ui.resourceUri` so text-only clients get plain responses.
+
+---
+
+## Step 3: Create the Widget Entry Point
+
+Create `widgets/src/widgets/my-widget.tsx`. The filename determines the widget ID — it must match the `id` field in your `WidgetDescriptor`.
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import MyWidget from '../my-widget/MyWidget';
+import '../index.css';
+
+// Widget entry point - mounts the MyWidget component
+const rootElement = document.getElementById('my-widget-root');
+if (rootElement) {
+  createRoot(rootElement).render(
+    <StrictMode>
+      <MyWidget />
+    </StrictMode>
+  );
+}
+```
+
+The Vite plugin scans `widgets/src/widgets/*.{tsx,jsx}` automatically — no build config changes needed.
+
+---
+
+## Step 4: Create the Widget Component
+
+Create `widgets/src/my-widget/MyWidget.tsx`. Follow the Echo component pattern in `widgets/src/echo/Echo.tsx`:
+
+- Accept an optional `app?: AppLike<MyToolOutput>` prop (enables Storybook / test injection via `createMockApp()`)
+- Fall back to `new App(...)` when no prop is provided
+- Register `ontoolresult` and `onhostcontextchanged` handlers **before** calling `activeApp.connect()` inside a `useEffect`
+- Apply safe area insets and container dimensions from `hostContext` for responsive sizing
+
+Key imports:
+
+```typescript
+import { App } from '@modelcontextprotocol/ext-apps';
+import type { AppLike, HostContext, ToolResultPayload } from '../types/mcp-app';
+import type { MyToolOutput } from 'chatgpt-app-server/types';
+```
+
+---
+
+## Step 5: Add a Storybook Story (Optional but Recommended)
+
+Create `widgets/src/my-widget/MyWidget.stories.tsx`. Use `createMockApp()` from `widgets/src/mocks/mock-app.ts` to simulate tool results:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { createMockApp } from '../mocks/mock-app';
+import MyWidget from './MyWidget';
+import type { MyToolOutput } from 'chatgpt-app-server/types';
+
+const meta: Meta<typeof MyWidget> = {
+  component: MyWidget,
+};
+export default meta;
+
+export const Default: StoryObj<typeof MyWidget> = {
+  args: {
+    app: createMockApp<MyToolOutput>({
+      toolResult: { result: 'Hello!', timestamp: new Date().toISOString() },
+    }),
+  },
+};
+```
+
+---
+
+## Step 6: Verify
+
+```bash
+npm run dev          # starts server (:8080) + widget dev server (:4444)
+npm run type-check   # catch TypeScript errors across all workspaces
+npm test             # run server + widget tests
+npm run storybook    # review the widget in isolation
+```
+
+The widget is auto-discovered — no additional registration or config changes required beyond `server.ts`.

--- a/.agents/skills/create-mcp-tool/SKILL.md
+++ b/.agents/skills/create-mcp-tool/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: create-mcp-tool
+description: Add a plain (text-only) or UI-enhanced MCP tool to this template's server. Use when asked to "add a tool", "add an MCP tool", "create a new tool", "add a server-side tool without a widget", "add a tool with a UI", "add a tool with a widget", or "create a tool and a widget".
+metadata:
+  author: nickytonline
+  version: "1.0.0"
+---
+
+# Add an MCP Tool to This Template
+
+Fetch the upstream `add-app-to-server` skill for core SDK patterns, then apply them using the template-specific conventions below:
+
+```
+https://raw.githubusercontent.com/modelcontextprotocol/ext-apps/main/plugins/mcp-apps/skills/add-app-to-server/SKILL.md
+```
+
+Use WebFetch to retrieve that skill now. The steps below cover what is **different** in this template.
+
+---
+
+## How This Template Differs from the Generic SDK Examples
+
+| Generic ext-apps approach | This template |
+|---|---|
+| Edit `server.ts` directly | Edit `server/src/server.ts` inside the `createMcpServer()` function |
+| Inline Zod schemas in the tool handler | Define schemas in `server/src/types.ts`, import into `server.ts` |
+| `vite-plugin-singlefile` for UI | Widget build system in `widgets/` — see the `add-widget` skill if you want a UI |
+| Single-file server | `SessionManager` in `server/src/utils/session.ts` handles per-session isolation |
+
+All tools must be registered inside `createMcpServer()` in `server/src/server.ts`. This function is called once per new MCP session, so each session gets its own isolated `McpServer` instance.
+
+---
+
+## Step 1: Define the Schema and Types
+
+Edit `server/src/types.ts`. Every tool input must have a Zod schema and an inferred TypeScript type:
+
+```typescript
+export const MyToolInputSchema = z.object({
+  query: z.string().describe('The search query'),
+  limit: z.number().int().min(1).max(50).optional().describe('Max results'),
+});
+export type MyToolInput = z.infer<typeof MyToolInputSchema>;
+
+export interface MyToolOutput {
+  results: string[];
+  count: number;
+  [key: string]: unknown;
+}
+```
+
+---
+
+## Step 2: Register the Tool
+
+Inside `createMcpServer()` in `server/src/server.ts`, use `registerAppTool` (already imported):
+
+### Text-only tool (no widget UI)
+
+```typescript
+registerAppTool(
+  server,
+  'my-tool',
+  {
+    title: 'My Tool',
+    description: 'Does something useful',
+    inputSchema: MyToolInputSchema.shape,
+  },
+  async (args) => {
+    sessionLogger.info({ toolName: 'my-tool', args }, 'Tool invoked');
+
+    const result = MyToolInputSchema.safeParse(args);
+    if (!result.success) {
+      return {
+        content: [{ type: 'text', text: `Error: ${result.error.issues.map(e => e.message).join(', ')}` }],
+        isError: true,
+      };
+    }
+
+    const output: MyToolOutput = {
+      results: ['a', 'b'],
+      count: 2,
+    };
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(output) }],
+    };
+  }
+);
+```
+
+### UI-enhanced tool (has a widget)
+
+When adding a UI, also follow the `add-widget` skill. The key addition is the `_meta.ui.resourceUri` field, gated on `canRenderUiByCapability` so text-only hosts still get a usable plain-text response:
+
+```typescript
+registerAppTool(
+  server,
+  'my-tool',
+  {
+    title: 'My Tool',
+    description: 'Does something useful',
+    inputSchema: MyToolInputSchema.shape,
+    _meta: canRenderUiByCapability
+      ? { ui: { resourceUri: MY_WIDGET.uri } }
+      : {},
+  },
+  async (args) => {
+    // ... validate, compute output ...
+    return {
+      content: [{ type: 'text', text: 'Plain text fallback for non-UI hosts' }],
+      structuredContent: output,   // passed to the widget via App.ontoolresult
+    };
+  }
+);
+```
+
+---
+
+## Step 3: Write Tests
+
+Add tests in `server/tests/`. Follow the pattern of existing test files. Run with:
+
+```bash
+npm run test:server
+```
+
+---
+
+## Step 4: Verify
+
+```bash
+npm run dev          # start server + widget dev server
+npm run type-check   # TypeScript across all workspaces
+npm run lint         # ESLint
+npm run inspect      # test the tool with MCP Inspector
+```


### PR DESCRIPTION
Adds two AI agent skills to .agents/skills/ that teach agents the
template-specific conventions when building with this repo:

- add-widget: scaffolding a new React widget + MCP tool pair, covering the vite-plugin-widgets auto-discovery system, WidgetDescriptor pattern, readWidgetHtml(), AppLike/createMockApp() prop pattern, and Storybook setup. Delegates to the upstream create-mcp-app ext-apps skill for core SDK patterns.

- create-mcp-tool: registering a plain or UI-enhanced MCP tool inside createMcpServer(), with Zod schemas in types.ts and the canRenderUiByCapability gate. Delegates to the upstream add-app-to-server ext-apps skill and references add-widget for the UI layer.

Both skills fetch the relevant upstream ext-apps skill at runtime (via WebFetch) rather than duplicating SDK-level documentation.

Generated with [Devin](https://cli.devin.ai/docs)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>

Used the Adaptive model by Cognition.

Closes #52
