### PR TITLE
chore: renamed chatgpt-app-typescript-template to mcp-app-typescript-template in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ graph TD
 ### Installation & Setup
 
 ```bash
-git clone https://github.com/pomerium/chatgpt-app-typescript-template your-chatgpt-app
+git clone https://github.com/pomerium/mcp-app-typescript-template your-chatgpt-app
 cd your-chatgpt-app
 npm install
 npm run dev
@@ -76,15 +76,15 @@ You should see output indicating both servers are running successfully:
 ```
 ❯ npm run dev
 
-> chatgpt-app-typescript-template@1.0.0 dev
+> mcp-app-typescript-template@1.0.0 dev
 > concurrently "npm run dev:server" "npm run dev:widgets"
 
 [1]
-[1] > chatgpt-app-typescript-template@1.0.0 dev:widgets
+[1] > mcp-app-typescript-template@1.0.0 dev:widgets
 [1] > npm run dev --workspace=widgets
 [1]
 [0]
-[0] > chatgpt-app-typescript-template@1.0.0 dev:server
+[0] > mcp-app-typescript-template@1.0.0 dev:server
 [0] > npm run dev --workspace=server
 [0]
 [1]
@@ -108,7 +108,7 @@ You should see output indicating both servers are running successfully:
 [0]     port: 8080
 [0]     nodeEnv: "development"
 [0]     logLevel: "info"
-[0]     assetsDir: "/Users/nicktaylor/dev/oss/chatgpt-app-typescript-template/assets"
+[0]     assetsDir: "/Users/nicktaylor/dev/oss/mcp-app-typescript-template/assets"
 [0] [12:45:12] INFO: Server started successfully
 [0]     port: 8080
 [0]     mcpEndpoint: "http://localhost:8080/mcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "chatgpt-app-typescript-template",
+  "name": "mcp-app-typescript-template",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "chatgpt-app-typescript-template",
+      "name": "mcp-app-typescript-template",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chatgpt-app-typescript-template",
+  "name": "mcp-app-typescript-template",
   "version": "1.0.0",
   "description": "Minimal, production-ready MCP Apps template with React widgets",
   "type": "module",


### PR DESCRIPTION
## Summary

Renamed `chatgpt-app-typescript-template` to `mcp-app-typescript-template` in files where the old repo name was referenced.

Relates to #75

## AI Disclosure

Just good old search and replace was used.