### PR TITLE
chore: rename chatgpt-app-* references to mcp-app-*

### DIFF
--- a/.agents/skills/add-widget/SKILL.md
+++ b/.agents/skills/add-widget/SKILL.md
@@ -116,7 +116,7 @@ Key imports:
 ```typescript
 import { App } from '@modelcontextprotocol/ext-apps';
 import type { AppLike, HostContext, ToolResultPayload } from '../types/mcp-app';
-import type { MyToolOutput } from 'chatgpt-app-server/types';
+import type { MyToolOutput } from 'mcp-app-server/types';
 ```
 
 ---
@@ -129,7 +129,7 @@ Create `widgets/src/my-widget/MyWidget.stories.tsx`. Use `createMockApp()` from 
 import type { Meta, StoryObj } from '@storybook/react';
 import { createMockApp } from '../mocks/mock-app';
 import MyWidget from './MyWidget';
-import type { MyToolOutput } from 'chatgpt-app-server/types';
+import type { MyToolOutput } from 'mcp-app-server/types';
 
 const meta: Meta<typeof MyWidget> = {
   component: MyWidget,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,7 +483,7 @@ The server will:
 ### Docker Deployment
 
 ```bash
-docker build -f docker/Dockerfile -t chatgpt-app:latest .
+docker build -f docker/Dockerfile -t mcp-app:latest .
 docker-compose -f docker/docker-compose.yml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ graph TD
 ### Installation & Setup
 
 ```bash
-git clone https://github.com/pomerium/mcp-app-typescript-template your-chatgpt-app
-cd your-chatgpt-app
+git clone https://github.com/pomerium/mcp-app-typescript-template your-mcp-app
+cd your-mcp-app
 npm install
 npm run dev
 ```
@@ -88,11 +88,11 @@ You should see output indicating both servers are running successfully:
 [0] > npm run dev --workspace=server
 [0]
 [1]
-[1] > chatgpt-app-widgets@1.0.0 dev
+[1] > mcp-app-widgets@1.0.0 dev
 [1] > vite
 [1]
 [0]
-[0] > chatgpt-app-server@1.0.0 dev
+[0] > mcp-app-server@1.0.0 dev
 [0] > tsx watch src/server.ts
 [0]
 [1]
@@ -289,7 +289,7 @@ When deploying to production:
 ## Project Structure
 
 ```
-chatgpt-app-template/
+mcp-app-template/
 ├── server/                  # MCP server
 │   ├── src/
 │   │   ├── server.ts       # Main server with echo tool
@@ -894,7 +894,7 @@ The server will:
 
 ```bash
 # Build image
-docker build -f docker/Dockerfile -t chatgpt-app:latest .
+docker build -f docker/Dockerfile -t mcp-app:latest .
 
 # Run with docker-compose
 docker-compose -f docker/docker-compose.yml up -d

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for ChatGPT App Template
+# Multi-stage build for MCP App Template
 # Using slim instead of alpine for better compatibility with native dependencies
 # Node.js 24+ required for ES2023 support and native type stripping
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
       target: production
-    image: chatgpt-app-template:latest
-    container_name: chatgpt-app-template
+    image: mcp-app-template:latest
+    container_name: mcp-app-template
     restart: unless-stopped
 
     ports:

--- a/mcp-inspector.json
+++ b/mcp-inspector.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "chatgpt-app-template": {
+    "mcp-app-template": {
       "type": "streamable-http",
       "url": "http://localhost:8080/mcp"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6011,14 +6011,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chatgpt-app-server": {
-      "resolved": "server",
-      "link": true
-    },
-    "node_modules/chatgpt-app-widgets": {
-      "resolved": "widgets",
-      "link": true
-    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -6692,16 +6684,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -10756,6 +10738,14 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mcp-app-server": {
+      "resolved": "server",
+      "link": true
+    },
+    "node_modules/mcp-app-widgets": {
+      "resolved": "widgets",
+      "link": true
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
@@ -17395,7 +17385,7 @@
       }
     },
     "server": {
-      "name": "chatgpt-app-server",
+      "name": "mcp-app-server",
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.1",
@@ -17432,7 +17422,7 @@
       "license": "MIT"
     },
     "widgets": {
-      "name": "chatgpt-app-widgets",
+      "name": "mcp-app-widgets",
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.1",
@@ -17458,8 +17448,8 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.5",
-        "chatgpt-app-server": "*",
         "jsdom": "^29.1.0",
+        "mcp-app-server": "*",
         "serve": "^14.2.6",
         "storybook": "^10.2.10",
         "tailwindcss": "^4.1.18",

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chatgpt-app-server",
+  "name": "mcp-app-server",
   "version": "1.0.0",
   "description": "MCP server for MCP Apps template",
   "type": "module",

--- a/widgets/package.json
+++ b/widgets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chatgpt-app-widgets",
+  "name": "mcp-app-widgets",
   "version": "1.0.0",
   "description": "React widgets for MCP Apps template",
   "type": "module",
@@ -39,7 +39,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
-    "chatgpt-app-server": "*",
+    "mcp-app-server": "*",
     "jsdom": "^29.1.0",
     "serve": "^14.2.6",
     "storybook": "^10.2.10",

--- a/widgets/src/echo/Echo.stories.tsx
+++ b/widgets/src/echo/Echo.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Echo from './Echo.js';
-import type { EchoToolOutput } from 'chatgpt-app-server/types';
+import type { EchoToolOutput } from 'mcp-app-server/types';
 import { createMockApp } from '../mocks/mock-app';
 
 const meta = {

--- a/widgets/src/echo/Echo.tsx
+++ b/widgets/src/echo/Echo.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { App } from '@modelcontextprotocol/ext-apps';
 import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
 import { Button } from '@/components/ui/button';
-import type { EchoToolOutput } from 'chatgpt-app-server/types';
+import type { EchoToolOutput } from 'mcp-app-server/types';
 import {
   BrainCircuit,
   ExternalLink,
@@ -272,7 +272,7 @@ export default function Echo({ app }: { app?: AppLike<EchoToolOutput> }) {
           Echo
         </h1>
         <p className="text-base dark:text-zinc-400 text-zinc-600">
-          A demonstration of ChatGPT widget capabilities
+          A demonstration of MCP Apps widget capabilities
         </p>
 
         <section className="space-y-2">

--- a/widgets/tests/Echo.test.tsx
+++ b/widgets/tests/Echo.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import Echo from '../src/echo/Echo.js';
 import { createMockApp } from '../src/mocks/mock-app.js';
-import type { EchoToolOutput } from 'chatgpt-app-server/types';
+import type { EchoToolOutput } from 'mcp-app-server/types';
 
 describe('Echo', () => {
   it('should render the echoed message', async () => {


### PR DESCRIPTION
Cleans up leftover `chatgpt-app-*` naming left over from the project rename to `mcp-app-typescript-template` that didn't match up exactly. TLDR; I should've made the name replacing a little broader in #75.

Updates internal workspace package names (`chatgpt-app-server`/`chatgpt-app-widgets` -> `mcp-app-server`/`mcp-app-widgets`), import paths, Docker image/container names, `mcp-inspector.json` label, and docs to match.

No functional changes.

Relates to #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)/edited by me.

## AI Disclosure

PR generated by Claude Code (Sonnet 5) with me making some manual edits.